### PR TITLE
feat: add calendar with date selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.11",
+        "date-fns": "^4.1.0",
         "react": "^19.1.0",
-        "react-datepicker": "^8.4.0",
+        "react-day-picker": "^9.8.0",
         "react-dom": "^19.1.0",
         "tailwindcss": "^4.1.11"
       },
@@ -41,6 +42,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.2.0.tgz",
+      "integrity": "sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.6",
@@ -624,59 +631,6 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
-    },
-    "node_modules/@floating-ui/core": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.2.tgz",
-      "integrity": "sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.10"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.2.tgz",
-      "integrity": "sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/core": "^1.7.2",
-        "@floating-ui/utils": "^0.2.10"
-      }
-    },
-    "node_modules/@floating-ui/react": {
-      "version": "0.27.13",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.13.tgz",
-      "integrity": "sha512-Qmj6t9TjgWAvbygNEu1hj4dbHI9CY0ziCMIJrmYoDIn9TUAH5lRmiIeZmRd4c6QEZkzdoH7jNnoNyoY1AIESiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react-dom": "^2.1.4",
-        "@floating-ui/utils": "^0.2.10",
-        "tabbable": "^6.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=17.0.0",
-        "react-dom": ">=17.0.0"
-      }
-    },
-    "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.4.tgz",
-      "integrity": "sha512-JbbpPhp38UmXDDAu60RJmbeme37Jbgsm7NrHGgzYYFKmblzRUh6Pa641dII6LsjwF4XlScDrde2UAzDo/b9KPw==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.7.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
-      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -2018,15 +1972,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2095,6 +2040,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
       }
+    },
+    "node_modules/date-fns-jalali": {
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -3252,19 +3203,25 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-datepicker": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-8.4.0.tgz",
-      "integrity": "sha512-6nPDnj8vektWCIOy9ArS3avus9Ndsyz5XgFCJ7nBxXASSpBdSL6lG9jzNNmViPOAOPh6T5oJyGaXuMirBLECag==",
+    "node_modules/react-day-picker": {
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.8.0.tgz",
+      "integrity": "sha512-E0yhhg7R+pdgbl/2toTb0xBhsEAtmAx1l7qjIWYfcxOy8w4rTSVfbtBoSzVVhPwKP/5E9iL38LivzoE3AQDhCQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/react": "^0.27.3",
-        "clsx": "^2.1.1",
-        "date-fns": "^4.1.0"
+        "@date-fns/tz": "1.2.0",
+        "date-fns": "4.1.0",
+        "date-fns-jalali": "4.1.0-0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
       },
       "peerDependencies": {
-        "react": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {
@@ -3439,12 +3396,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/tabbable": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.11",
+    "date-fns": "^4.1.0",
     "react": "^19.1.0",
-    "react-datepicker": "^8.4.0",
+    "react-day-picker": "^9.8.0",
     "react-dom": "^19.1.0",
     "tailwindcss": "^4.1.11"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,10 @@
 import useReservation from "./hooks/useReservation";
 import HourStep from "./components/HourStep";
 import CourtStep from "./components/CourtStep";
+import CalendarStep from "./components/CalendarStep";
 
 function App() {
-  const { step, reservation, setReservation, nextStep, prevStep } =
+  const { step, reservation, updateDate, setReservation, nextStep, prevStep } =
     useReservation();
 
   return (
@@ -32,7 +33,15 @@ function App() {
           onBack={prevStep}
         />
       )}
-      {/* Add other steps like CalendarStep and TimeSlotsStep here */}
+      {step === "calendar" && (
+        <CalendarStep
+          onDateSelect={(date) => {
+            updateDate(date); // Actualiza el estado global
+            nextStep(); // Avanza a time-slots
+          }}
+          onBack={prevStep}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/CalendarStep.tsx
+++ b/src/components/CalendarStep.tsx
@@ -1,36 +1,46 @@
-import { useState } from "react";
-import DatePicker from "react-datepicker";
+import { DayPicker } from "react-day-picker";
 import { es } from "date-fns/locale"; // Soporte para español
+import "react-day-picker/dist/style.css";
+import { useState } from "react";
 
-import "react-datepicker/dist/react-datepicker.css";
-
-type CalendarProps = {
+type CalendarStepProps = {
   onDateSelect: (date: Date) => void;
+  onBack: () => void;
 };
 
-export default function Calendar({ onDateSelect }: CalendarProps) {
-  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+export default function CalendarStep({
+  onDateSelect,
+  onBack,
+}: CalendarStepProps) {
+  const today = new Date();
+  const currentMonth = new Date(today.getFullYear(), today.getMonth());
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>();
+
+  // Deshabilita días pasados y domingos
+
+  // 0 = Domingo
+  const isDayDisabled = (day: Date) => day < today || day.getDay() === 0;
 
   return (
-    <div className="p-4 bg-white rounded-lg shadow">
-      <h2 className="text-xl font-bold text-gray-800 mb-4">
-        Elegí fecha y hora
-      </h2>
-      <DatePicker
+    <div className="space-y-4">
+      <DayPicker
+        mode="single"
         selected={selectedDate}
-        onChange={(date) => {
+        onSelect={(date) => {
           setSelectedDate(date);
           if (date) onDateSelect(date);
         }}
-        showTimeSelect
-        timeFormat="HH:mm"
-        timeIntervals={30}
-        dateFormat="Pp" // Nuevo formato estándar (ej: "15/07/2024, 14:30")
-        minDate={new Date()}
-        locale={es} // Español (fijarse si tengo que instalar date-fns)
-        className="input input-bordered w-full"
-        placeholderText="Selecciona una fecha"
+        defaultMonth={currentMonth}
+        disabled={isDayDisabled}
+        modifiersClassNames={{
+          selected: "bg-primary text-white",
+          disabled: "text-gray-400 cursor-not-allowed",
+        }}
+        locale={es}
       />
+      <button onClick={onBack} className="btn btn-outline mt-4">
+        ← Volver
+      </button>
     </div>
   );
 }

--- a/src/hooks/useReservation.ts
+++ b/src/hooks/useReservation.ts
@@ -2,13 +2,24 @@ import { useState } from "react";
 
 type StepType = "hours" | "courts" | "calendar" | "time-slots";
 
+type Reservation = {
+  hours: number;
+  court: string;
+  date: Date | null;
+};
+
 export default function useReservation() {
   const [step, setStep] = useState<StepType>("hours");
-  const [reservation, setReservation] = useState({
+  const [reservation, setReservation] = useState<Reservation>({
     hours: 0,
     court: "",
-    date: null as Date | null,
+    date: null,
   });
+
+  // Actualizacion especifica para la fecha
+  const updateDate = (date: Date) => {
+    setReservation((prev) => ({ ...prev, date }));
+  };
 
   const nextStep = () => {
     if (step === "hours") setStep("courts");
@@ -22,5 +33,5 @@ export default function useReservation() {
     else if (step === "time-slots") setStep("calendar");
   };
 
-  return { step, reservation, setReservation, nextStep, prevStep };
+  return { step, reservation, updateDate, setReservation, nextStep, prevStep };
 }


### PR DESCRIPTION
## Qué hace este PR
- Añade calendario interactivo para seleccionar fechas.
- Deshabilita fechas pasadas automáticamente.

## Screenshot
![image](https://i.imgur.com/ejemplo.png)

## Cómo probarlo
1. Ejecutar `npm run dev`
2. Navegar a `/reservations`
3. Seleccionar una fecha válida (futura).