### PR TITLE
feat: agregar botón de volver en HourStep y ajustes UX

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-// App.tsx
 import useReservation from "./hooks/useReservation";
 import HourStep from "./components/HourStep";
 import CourtStep from "./components/CourtStep";
@@ -15,29 +14,32 @@ function App() {
         <p className="text-gray-600">Calle Demo 1234 ★★★★★</p>
       </header>
 
+      {step === "calendar" && (
+        <CalendarStep
+          onDateSelect={(date) => {
+            updateDate(date);
+            nextStep();
+          }}
+          onBack={() => {}} // no hay back desde el primer paso
+        />
+      )}
+
       {step === "hours" && (
         <HourStep
           onSelect={(hours) => {
             setReservation({ ...reservation, hours });
             nextStep();
           }}
+          onBack={prevStep}
         />
       )}
+
       {step === "courts" && (
         <CourtStep
           courts={["Cancha 1", "Cancha 2", "Cancha 3"]}
           onSelect={(court) => {
             setReservation({ ...reservation, court });
             nextStep();
-          }}
-          onBack={prevStep}
-        />
-      )}
-      {step === "calendar" && (
-        <CalendarStep
-          onDateSelect={(date) => {
-            updateDate(date); // Actualiza el estado global
-            // Avanza a time-slots
           }}
           onBack={prevStep}
         />

--- a/src/components/HourStep.tsx
+++ b/src/components/HourStep.tsx
@@ -2,8 +2,10 @@ import Card from "./UI/Card";
 
 export default function HourStep({
   onSelect,
+  onBack,
 }: {
   onSelect: (hours: number) => void;
+  onBack: () => void;
 }) {
   const options = [
     { hours: 1, price: 5000 },
@@ -27,6 +29,9 @@ export default function HourStep({
           </div>
         </button>
       ))}
+      <button className="btn btn-soft mt-4" onClick={onBack}>
+       ← volver
+      </button>
     </Card>
   );
 }

--- a/src/components/UI/Card.tsx
+++ b/src/components/UI/Card.tsx
@@ -1,8 +1,35 @@
-export default function Card({ children, title }: { children: React.ReactNode; title?: string }) {
+export default function Card({
+  children,
+  title,
+}: {
+  children: React.ReactNode;
+  title?: string;
+}) {
   return (
-    <div className="bg-white rounded-lg shadow-md p-4 mb-4 fade-in">
-      {title && <h2 className="text-xl text-gray-800 font-semibold mb-4">{title}</h2>}
-      {children}
+    <div className="bg-white rounded-lg shadow-md">
+      <div className="p-4 border-b border-gray-200 flex justify-between items-center">
+        {title && (
+          <h2 className="text-xl text-gray-800 font-semibold p-0.5">{title}</h2>
+        )}
+        <a href="#" className="text-gray-500 hover:text-gray-700">
+          {/* Icono de cerrar */}
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-6 w-6"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </a>
+      </div>
+      <div className="p-4 flex flex-col justify-center items-center text-base-100">{children}</div>
     </div>
   );
 }


### PR DESCRIPTION
### Cambios

- Se modificó el flujo de pasos del proceso de reserva: ahora primero se elige la fecha, luego la duración del turno y por último la cancha.
- Se habilitó la selección del día actual en el calendario, excepto los domingos.
- Se agregó el botón de volver en el paso de selección de duración.
- Se ajustó el componente `Card` para mejorar la visual y coherencia del diseño.

### Motivo

Estos cambios mejoran la experiencia del usuario y preparan la base para agregar la lógica de horarios disponibles por cancha.

### Próximos pasos

Implementar el componente `TimeSlotStep` con horarios disponibles según fecha, duración y cancha.